### PR TITLE
[Feature] Auto update using registry in check

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -4,48 +4,29 @@ const yargs = require('yargs');
 const figlet = require('figlet');
 
 const {DisposableMail} = require('../src/index');
-const axios = require('axios');
+const {autoUpdateChecker} = require('../src/service/autoUpdateChecker');
 const mail = new DisposableMail();
-const PACKAGE_NAME = 'disposable-mail-api';
 
 _banner();
 
-const options = yargs.usage('Usage: -u <username>').options({
-  u: {
-    alias: 'username',
-    describe: 'Your username for mail creation',
-    type: 'string',
-    demandOption: true,
-  },
-  s: {
-    alias: 'skip',
-    describe: 'Skip latest version check',
-    type: 'boolean',
-    demandOption: false,
-    default: false,
-  },
-  y: {
-    alias: 'yes',
-    describe:
-      'Default yes to all prompts. Currently only works for auto-update',
-    type: 'boolean',
-    demandOption: false,
-    default: false,
-  },
-}).argv;
+const options = yargs
+    .usage('Usage: -u <username>')
+    .option('u', {alias: 'username', describe: 'Your username for mail creation', type: 'string', demandOption: true})
+    .option('html',
+        {describe: 'Displays mail with plain html', type: 'boolean', demandOption: false, default: false})
+    .argv;
 
 (async () => {
-  if (!options.skip) {
-    await checkForUpdates();
-  }
+  autoUpdateChecker();
 
   const createMail = await mail.generate({username: options.username});
   console.log(`Mail created => ${createMail.address}`);
   console.log('Listening for mails...');
 
+
   let counterMailsShowed = 0;
   setInterval(async () => {
-    const getInboxMail = await mail.inbox();
+    const getInboxMail = await mail.inbox({withHtml: options?.html});
     if (getInboxMail.mailInbox.length !== counterMailsShowed) {
       _displayMail(getInboxMail.mailInbox[0]);
       counterMailsShowed++;
@@ -54,9 +35,7 @@ const options = yargs.usage('Usage: -u <username>').options({
 })();
 
 function _displayMail(mail) {
-  console.log(
-      `---------------------------- NEW MAIL ----------------------------`
-  );
+  console.log(`---------------------------- NEW MAIL ----------------------------`);
   console.log(`>> From: ${mail.from.name} <${mail.from.address}>`);
   console.log(`>> Subject: ${mail.subject}`);
   console.log(`>> Intro: ${mail.intro}`);
@@ -64,105 +43,6 @@ function _displayMail(mail) {
 }
 
 function _banner() {
-  figlet('Disposable Mail', {font: '3D Diagonal'}, (err, data) =>
-    console.log(data)
-  );
+  figlet('Disposable Mail', {font: '3D Diagonal'}, (_, data) => console.log(data));
 }
 
-// Auto update stuff
-
-function newVersionBanner(currentVersion, latestVersion, string = null) {
-  const strings = [
-    string ||
-      `| New version available: ${currentVersion} => ${latestVersion} |`,
-    '\x1b[31m',
-    `| Please run 'npm i ${PACKAGE_NAME}@latest -g' |`,
-    '\x1b[0m',
-  ];
-  const maxStringLength = Math.max(...strings.map((s) => s.length));
-
-  console.log(
-      '-'.repeat(maxStringLength),
-      strings.join('\n'),
-      '-'.repeat(maxStringLength)
-  );
-}
-
-// False is always No and Yes is always true
-async function yesNoDialog(str, defaultAnswer = true) {
-  const readline = require('readline').createInterface({
-    input: process.stdin,
-    output: process.stdout,
-  });
-
-  const options = defaultAnswer ? '[Y/n]' : '[y/N]';
-  const question = `${str} ${options} `;
-
-  const answer = readline.question(question, (userAnswer) => {
-    if (!userAnswer) {
-      return defaultAnswer;
-    }
-
-    return userAnswer.toLowerCase().startsWith('y');
-  });
-
-  return answer;
-}
-
-// Helper function to reduce code complexity in the conditional
-function checkShouldBeUpdated() {
-  return (
-    options.yes ||
-    yesNoDialog(
-        'New version available. Do you want to update to latest version?',
-        false
-    )
-  );
-}
-
-function checkLatestVersion(localVersion, remoteVersion) {
-  return localVersion.toString() !== remoteVersion.toString();
-}
-
-async function checkForUpdates() {
-  const {version: localVersion} = require('../package.json');
-  const NPM_REGISTRY_DATA = `https://registry.npmjs.org/${PACKAGE_NAME}/latest`;
-  const {
-    data: {version: remoteVersion},
-  } = await axios.get(NPM_REGISTRY_DATA);
-
-  const isLatestVersion = checkLatestVersion(localVersion, remoteVersion);
-
-  if (isLatestVersion && checkShouldBeUpdated()) {
-    autoUpdate(localVersion, remoteVersion);
-  }
-
-  if (isLatestVersion && !checkShouldBeUpdated()) {
-    newVersionBanner(localVersion, remoteVersion);
-  }
-}
-
-function autoUpdate(localVersion, remoteVersion) {
-  const {execSync} = require('node:child_process');
-
-  try {
-    execSync(`npm i ${PACKAGE_NAME}@latest -g`);
-  } catch (e) {
-    newVersionBanner(
-        localVersion,
-        remoteVersion,
-        `Error while updating ${PACKAGE_NAME}: Update manually`
-    );
-    return;
-  }
-
-  try {
-    execSync(process.argv.join(' '));
-    process.exit(0);
-  } catch (error) {
-    console.error(
-        'Error while running updated version. Update manually or run with --skip option.'
-    );
-    process.exit(1);
-  }
-}

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -5,9 +5,7 @@ const figlet = require('figlet');
 
 const {DisposableMail} = require('../src/index');
 const {autoUpdateChecker} = require('../src/service/autoUpdateChecker');
-const mail = new DisposableMail();
 
-_banner();
 
 const options = yargs
     .usage('Usage: -u <username>')
@@ -17,21 +15,30 @@ const options = yargs
     .argv;
 
 (async () => {
-  autoUpdateChecker();
+  await autoUpdateChecker();
 
-  const createMail = await mail.generate({username: options.username});
-  console.log(`Mail created => ${createMail.address}`);
-  console.log('Listening for mails...');
+  const mail = new DisposableMail();
+
+  _banner();
+
+  try {
+    const createMail = await mail.generate({username: options.username});
+    console.log(`Mail created => ${createMail.address}`);
+    console.log('Listening for mails...');
 
 
-  let counterMailsShowed = 0;
-  setInterval(async () => {
-    const getInboxMail = await mail.inbox({withHtml: options?.html});
-    if (getInboxMail.mailInbox.length !== counterMailsShowed) {
-      _displayMail(getInboxMail.mailInbox[0]);
-      counterMailsShowed++;
-    }
-  }, 7000);
+    let counterMailsShowed = 0;
+    setInterval(async () => {
+      const getInboxMail = await mail.inbox({withHtml: options?.html});
+      if (getInboxMail.mailInbox.length !== counterMailsShowed) {
+        _displayMail(getInboxMail.mailInbox[0]);
+        counterMailsShowed++;
+      }
+    }, 7000);
+  } catch (error) {
+    console.error(`ERROR! ${error.message}`);
+    process.exit(1);
+  }
 })();
 
 function _displayMail(mail) {

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -5,26 +5,43 @@ const figlet = require('figlet');
 
 const {DisposableMail} = require('../src/index');
 const axios = require('axios');
-const {version} = require('../package.json');
 const mail = new DisposableMail();
+const PACKAGE_NAME = 'disposable-mail-api';
 
 _banner();
 
-const options = yargs
-    .usage('Usage: -u <username>')
-    .option('u', {alias: 'username', describe: 'Your username for mail creation', type: 'string', demandOption: true})
-    .argv;
-
+const options = yargs.usage('Usage: -u <username>').options({
+  u: {
+    alias: 'username',
+    describe: 'Your username for mail creation',
+    type: 'string',
+    demandOption: true,
+  },
+  s: {
+    alias: 'skip',
+    describe: 'Skip latest version check',
+    type: 'boolean',
+    demandOption: false,
+    default: false,
+  },
+  y: {
+    alias: 'yes',
+    describe:
+      'Default yes to all prompts. Currently only works for auto-update',
+    type: 'boolean',
+    demandOption: false,
+    default: false,
+  },
+}).argv;
 
 (async () => {
-  const {data: {version: remoteVersion}} = await axios
-      .get('https://raw.githubusercontent.com/EsteveSegura/disposable-mail-api/main/package.json');
-  checkForUpdates(version, remoteVersion);
+  if (!options.skip) {
+    await checkForUpdates();
+  }
 
   const createMail = await mail.generate({username: options.username});
   console.log(`Mail created => ${createMail.address}`);
   console.log('Listening for mails...');
-
 
   let counterMailsShowed = 0;
   setInterval(async () => {
@@ -37,7 +54,9 @@ const options = yargs
 })();
 
 function _displayMail(mail) {
-  console.log(`---------------------------- NEW MAIL ----------------------------`);
+  console.log(
+      `---------------------------- NEW MAIL ----------------------------`
+  );
   console.log(`>> From: ${mail.from.name} <${mail.from.address}>`);
   console.log(`>> Subject: ${mail.subject}`);
   console.log(`>> Intro: ${mail.intro}`);
@@ -45,11 +64,105 @@ function _displayMail(mail) {
 }
 
 function _banner() {
-  figlet('Disposable Mail', {font: '3D Diagonal'}, (err, data) => console.log(data));
+  figlet('Disposable Mail', {font: '3D Diagonal'}, (err, data) =>
+    console.log(data)
+  );
 }
 
-function checkForUpdates(localVersion, remoteVersion) {
-  if (localVersion.toString() !== remoteVersion.toString()) {
-    console.log('New version available, please run:', '\x1b[31m', '\'npm i disposable-mail-api@latest -g\'', '\x1b[0m');
+// Auto update stuff
+
+function newVersionBanner(currentVersion, latestVersion, string = null) {
+  const strings = [
+    string ||
+      `| New version available: ${currentVersion} => ${latestVersion} |`,
+    '\x1b[31m',
+    `| Please run 'npm i ${PACKAGE_NAME}@latest -g' |`,
+    '\x1b[0m',
+  ];
+  const maxStringLength = Math.max(...strings.map((s) => s.length));
+
+  console.log(
+      '-'.repeat(maxStringLength),
+      strings.join('\n'),
+      '-'.repeat(maxStringLength)
+  );
+}
+
+// False is always No and Yes is always true
+async function yesNoDialog(str, defaultAnswer = true) {
+  const readline = require('readline').createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  const options = defaultAnswer ? '[Y/n]' : '[y/N]';
+  const question = `${str} ${options} `;
+
+  const answer = readline.question(question, (userAnswer) => {
+    if (!userAnswer) {
+      return defaultAnswer;
+    }
+
+    return userAnswer.toLowerCase().startsWith('y');
+  });
+
+  return answer;
+}
+
+// Helper function to reduce code complexity in the conditional
+function checkShouldBeUpdated() {
+  return (
+    options.yes ||
+    yesNoDialog(
+        'New version available. Do you want to update to latest version?',
+        false
+    )
+  );
+}
+
+function checkLatestVersion(localVersion, remoteVersion) {
+  return localVersion.toString() !== remoteVersion.toString();
+}
+
+async function checkForUpdates() {
+  const {version: localVersion} = require('../package.json');
+  const NPM_REGISTRY_DATA = `https://registry.npmjs.org/${PACKAGE_NAME}/latest`;
+  const {
+    data: {version: remoteVersion},
+  } = await axios.get(NPM_REGISTRY_DATA);
+
+  const isLatestVersion = checkLatestVersion(localVersion, remoteVersion);
+
+  if (isLatestVersion && checkShouldBeUpdated()) {
+    autoUpdate(localVersion, remoteVersion);
+  }
+
+  if (isLatestVersion && !checkShouldBeUpdated()) {
+    newVersionBanner(localVersion, remoteVersion);
+  }
+}
+
+function autoUpdate(localVersion, remoteVersion) {
+  const {execSync} = require('node:child_process');
+
+  try {
+    execSync(`npm i ${PACKAGE_NAME}@latest -g`);
+  } catch (e) {
+    newVersionBanner(
+        localVersion,
+        remoteVersion,
+        `Error while updating ${PACKAGE_NAME}: Update manually`
+    );
+    return;
+  }
+
+  try {
+    execSync(process.argv.join(' '));
+    process.exit(0);
+  } catch (error) {
+    console.error(
+        'Error while running updated version. Update manually or run with --skip option.'
+    );
+    process.exit(1);
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "disposable-mail-api",
-  "version": "0.0.10",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "disposable-mail-api",
-      "version": "0.0.10",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.27.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "disposable-mail-api",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "disposable-mail-api",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.27.2",

--- a/src/service/autoUpdateChecker.js
+++ b/src/service/autoUpdateChecker.js
@@ -1,5 +1,5 @@
-import { ynInKey } from '../utils/ynInKey';
-import { getVersions } from './getVersions';
+import {ynInKey} from '../utils/ynInKey';
+import {getVersions} from './getVersions';
 
 function newVersionBanner(currentVersion, latestVersion, string = null) {
   const strings = [

--- a/src/service/autoUpdateChecker.js
+++ b/src/service/autoUpdateChecker.js
@@ -1,5 +1,5 @@
-import {ynInKey} from '../utils/ynInKey';
-import {getVersions} from './getVersions';
+const {ynInKey} = require('../utils/ynInKey');
+const {getVersions} = require('./getVersions');
 
 function newVersionBanner(currentVersion, latestVersion, string = null) {
   const strings = [
@@ -33,11 +33,13 @@ function update(packageName) {
   process.exit(0);
 }
 
-export function autoUpdateChecker() {
+function autoUpdateChecker() {
   const {localVersion, latestVersion, packageName} = getVersions();
   if (localVersion === latestVersion) return;
 
   newVersionBanner(localVersion, latestVersion);
 
-  ynInKey('Do you want to update now?').then(() => update(packageName)).catch(() => {});
+  ynInKey.ynInKey('Do you want to update now?').then(() => update(packageName)).catch(() => {});
 }
+
+module.exports ={autoUpdateChecker};

--- a/src/service/autoUpdateChecker.js
+++ b/src/service/autoUpdateChecker.js
@@ -1,0 +1,43 @@
+import { ynInKey } from '../utils/ynInKey';
+import { getVersions } from './getVersions';
+
+function newVersionBanner(currentVersion, latestVersion, string = null) {
+  const strings = [
+    `New version available: ${currentVersion} => ${latestVersion}`,
+    `Please run 'npm i ${PACKAGE_NAME}@latest -g'`,
+  ];
+
+  const maxStringLength = Math.max(...strings.map((s) => s.length));
+  const repeatLength = maxStringLength + 2;
+  const pattern = '-'.repeat(repeatLength);
+  const formattedStrings = strings.map((s) => s.padEnd(maxStringLength));
+  formattedStrings.unshift(' '.repeat(maxStringLength));
+  formattedStrings.push(' '.repeat(maxStringLength));
+
+  console.log(
+      `\n\t ${pattern}\n\t|`,
+      formattedStrings.join(' |\n\t| '),
+      `|\n\t ${pattern}`,
+      '\n'
+  );
+}
+
+function update(packageName) {
+  const {execSync} = require('child_process');
+  const command = `npm i ${packageName}@latest -g`;
+  console.log(`Running '${command}'...`);
+  execSync(command, {stdio: 'inherit'});
+  console.log('Done!');
+
+  execSync(process.argv.join(' '), {stdio: 'inherit'});
+  process.exit(0);
+}
+
+export function autoUpdateChecker() {
+  const {localVersion, latestVersion, packageName} = getVersions();
+  if (localVersion === latestVersion) return;
+
+  newVersionBanner(localVersion, latestVersion);
+
+  ynInKey('Do you want to update now?').then(() => update(packageName)).catch(() => {});
+}

--- a/src/service/autoUpdateChecker.js
+++ b/src/service/autoUpdateChecker.js
@@ -1,5 +1,6 @@
 const {ynInKey} = require('../utils/ynInKey');
 const {getVersions} = require('./getVersions');
+const {name: PACKAGE_NAME} = require('../../package.json');
 
 function newVersionBanner(currentVersion, latestVersion, string = null) {
   const strings = [
@@ -22,9 +23,9 @@ function newVersionBanner(currentVersion, latestVersion, string = null) {
   );
 }
 
-function update(packageName) {
+function update() {
   const {execSync} = require('child_process');
-  const command = `npm i ${packageName}@latest -g`;
+  const command = `npm i ${PACKAGE_NAME}@latest -g`;
   console.log(`Running '${command}'...`);
   execSync(command, {stdio: 'inherit'});
   console.log('Done!');
@@ -33,13 +34,15 @@ function update(packageName) {
   process.exit(0);
 }
 
-function autoUpdateChecker() {
-  const {localVersion, latestVersion, packageName} = getVersions();
-  if (localVersion === latestVersion) return;
+async function autoUpdateChecker() {
+  try {
+    const {localVersion, latestVersion} = await getVersions();
+    if (localVersion === latestVersion) return;
 
-  newVersionBanner(localVersion, latestVersion);
+    newVersionBanner(localVersion, latestVersion);
 
-  ynInKey.ynInKey('Do you want to update now?').then(() => update(packageName)).catch(() => {});
+    await ynInKey('Do you want to update now?', false).then(() => update());
+  } catch (error) {}
 }
 
 module.exports ={autoUpdateChecker};

--- a/src/service/getVersions.js
+++ b/src/service/getVersions.js
@@ -1,4 +1,4 @@
-const {version: LOCAL_VERSION} = require('../../package.json');
+const {version: LOCAL_VERSION, name} = require('../../package.json');
 
 async function getVersions() {
   const npmRegistryUrlForThisPackage = `https://registry.npmjs.org/${name}/latest`;

--- a/src/service/getVersions.js
+++ b/src/service/getVersions.js
@@ -1,4 +1,4 @@
-export async function getVersions() {
+async function getVersions() {
   const {
     version: localVersion,
     name,
@@ -10,3 +10,6 @@ export async function getVersions() {
 
   return {localVersion, latestVersion, packageName: name};
 }
+
+
+module.exports = {getVersions};

--- a/src/service/getVersions.js
+++ b/src/service/getVersions.js
@@ -1,0 +1,12 @@
+export async function getVersions() {
+  const {
+    version: localVersion,
+    name,
+  } = require('../package.json');
+  const npmRegistryUrlForThisPackage = `https://registry.npmjs.org/${name}/latest`;
+  const {
+    data: {version: latestVersion},
+  } = require('axios').get(npmRegistryUrlForThisPackage);
+
+  return {localVersion, latestVersion, packageName: name};
+}

--- a/src/service/getVersions.js
+++ b/src/service/getVersions.js
@@ -1,15 +1,12 @@
+const {version: LOCAL_VERSION} = require('../../package.json');
+
 async function getVersions() {
-  const {
-    version: localVersion,
-    name,
-  } = require('../package.json');
   const npmRegistryUrlForThisPackage = `https://registry.npmjs.org/${name}/latest`;
   const {
     data: {version: latestVersion},
   } = require('axios').get(npmRegistryUrlForThisPackage);
 
-  return {localVersion, latestVersion, packageName: name};
+  return {localVersion: LOCAL_VERSION, latestVersion};
 }
-
 
 module.exports = {getVersions};

--- a/src/utils/ynInKey.js
+++ b/src/utils/ynInKey.js
@@ -1,22 +1,14 @@
 const {createInterface} = require('node:readline/promises');
 
-async function ynInKey(questionPrompt = null, defaultAnswer = true, abortTime = 10_000, multiline = false) {
+async function ynInKey(questionPrompt = null, defaultAnswer = true, abortTime = 10_000) {
   const signal = AbortSignal.timeout(abortTime);
   const readline = createInterface({
     input: process.stdin,
     output: process.stdout,
   });
 
-  let prompt = '';
   const options = defaultAnswer ? '[Y/n]' : '[y/N]';
-  if (multiline) {
-    console.log(questionPrompt);
-    prompt = `${options} ${readline.getPrompt()}`;
-  }
-
-  if (!multiline) {
-    prompt = `${questionPrompt} ${options} ${readline.getPrompt()}`;
-  }
+  const prompt = `${questionPrompt} ${options} ${readline.getPrompt()}`;
 
   readline.question(prompt, {signal});
   return new Promise((resolve, reject) => {

--- a/src/utils/ynInKey.js
+++ b/src/utils/ynInKey.js
@@ -1,0 +1,36 @@
+const {createInterface} = require('node:readline/promises');
+
+export async function ynInKey(questionPrompt = null, defaultAnswer = true, abortTime = 10_000, multiline = false) {
+  const signal = AbortSignal.timeout(abortTime);
+  const readline = createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  let prompt = '';
+  const options = defaultAnswer ? '[Y/n]' : '[y/N]';
+  if (multiline) {
+    console.log(questionPrompt);
+    prompt = `${options} ${readline.getPrompt()}`;
+  }
+
+  if (!multiline) {
+    prompt = `${questionPrompt} ${options} ${readline.getPrompt()}`;
+  }
+
+  readline.question(prompt, {signal});
+  return new Promise((resolve, reject) => {
+    process.stdin.setRawMode(true);
+    process.stdin.resume();
+    process.stdin.on('data', (data) => {
+      process.stdin.pause();
+      console.log();
+      const key = data.toString('utf-8');
+      process.stdin.setRawMode(false);
+      readline.close();
+      if (key.toLowerCase() === 'y' || key.toLowerCase() !== 'n' && defaultAnswer) return resolve();
+
+      return reject(new Error('No'));
+    });
+  });
+}

--- a/src/utils/ynInKey.js
+++ b/src/utils/ynInKey.js
@@ -1,6 +1,6 @@
 const {createInterface} = require('node:readline/promises');
 
-export async function ynInKey(questionPrompt = null, defaultAnswer = true, abortTime = 10_000, multiline = false) {
+async function ynInKey(questionPrompt = null, defaultAnswer = true, abortTime = 10_000, multiline = false) {
   const signal = AbortSignal.timeout(abortTime);
   const readline = createInterface({
     input: process.stdin,
@@ -34,3 +34,5 @@ export async function ynInKey(questionPrompt = null, defaultAnswer = true, abort
     });
   });
 }
+
+module.exports = {ynInKey};


### PR DESCRIPTION
## Description

As proposed in #13 use registry to check lastest version because npm should be the true source due is the way to install this package.

I added options for skipping check and auto update.

## Examples

### Skip installation and updates check

If you want to skip check of latest version:

```
disposable-mail-api --skip --username <username>
```

**NOTE** There is no option to check but avoid auto update because, why you should want to be notified if you will be ignoring the update message?

### Proposed auto update but need user confirmation

Do it by regular call with no extra options:

```
$ disposable-mail-api --username <username>

 ---------------------------------------------------
|  New version available: 1.0.0 => 1.0.1                         |
|  Please run 'npm i disposable-mail-api@latest -g'  | 
 ---------------------------------------------------

Do you want to update now? [y/N]: 
```

### Update automatically

```
$ disposable-mail-api --username <username> -y

 ---------------------------------------------------
|  New version available: 1.0.0 => 1.0.1                         |
|  Please run 'npm i disposable-mail-api@latest -g'  | 
 ---------------------------------------------------

Updated to 1.0.1!
(...)
// Continues execution with new version
(...)
```

## TODO

 - [x] Use registry instead of github as source of thruth.
 - [x] Fixed banner shows after update, must be showed synchronously
 - [x] Option for skipping check
 - [x] Added auto update and option to automate update.